### PR TITLE
Enable CORS for preflight request

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ For the latest information on the API endpoints maintained, see the functions im
 
 Deployment to AWS is done locally on the command line and is _not_ yet connected to Github version control.
 
-The code can be deployed to either the dev account (`Innov-Platform-Dev`) or to the prod account (`Innov-Platform-Prod`). **Please be careful to deploy to the prod account only with extreme caution and after thoroughly testing changes in dev.**
+The code can be deployed to either the dev account (`Innov-Platform-Dev`) or to the prod account (`Innov-Platform-Prod`). 
+
+> :warning: Please be careful to deploy to the prod account only with extreme caution and after thoroughly testing changes in dev. **Make sure to test that sending requests to our redirect dummy app works before deploying to prod** (see [Test API Requests](#test-api-requests) for instructions). This ensures that the API works with requests sent to a redirect URL.
 
 1. Make code changes locally
 2. Test code changes locally
@@ -44,9 +46,22 @@ This template contains a single lambda function triggered by an HTTP request mad
 
 ### In dev
 
-In order to test functions, you can run the following mock requests from the "Testing" tab in the Lambda console for the appropriate function. Update the body of the request as needed to test different scenarios. **Please note that all requests will write directly to the Prod Google Sheet for the time being. After running requests, be sure to remove any changes from the spreadsheet.**
+#### Test API Requests
 
-#### Rating
+This section includes test requests for testing the Feedback API Lambdas/endpoints. Update the body of the request as needed to test different scenarios.
+
+There are three different methods for testing these requests:
+
+1. **Run requests as JSON via the AWS console**: Go to the "Testing" tab in the Lambda console for the appropriate function.
+2. **Send API requests to the dev API Gateway URL**. Go the API Gateway resource in the AWS console to find the URL. The URL can also be found in the ResX Bitwarden under the `Feedback API Testing Info` item.
+
+3. **Send API requests to our dummy app for testing redirects**. 
+    - In production, the frontend feedback widget doesn't send requests directly to the API Gateway URL. Instead, the widget sends requests to a URL on the Innovation site which then redirects to the prod API Gateway URL. **Testing via this method is crucial because the API can behave differently or even break depending on whether you call it directly vs. via a redirect** (e.g. due to CORS issues).
+    - The URL and test CURL requests can be found in the ResX Bitwarden under the `Feedback API Testing Info` item.
+
+> :warning: **Please note that all requests will write directly to the Prod Google Sheet for the time being.** After running requests, be sure to remove any changes from the spreadsheet
+
+##### Rating
 ```
 {
   "headers": {
@@ -56,7 +71,7 @@ In order to test functions, you can run the following mock requests from the "Te
 }
 ```
 
-#### Email
+##### Email
 ```
 {
   "headers": {
@@ -66,7 +81,7 @@ In order to test functions, you can run the following mock requests from the "Te
 }
 ```
 
-#### Comment
+##### Comment
 ```
 {
   "headers": {
@@ -75,8 +90,6 @@ In order to test functions, you can run the following mock requests from the "Te
   "body": "{\"feedbackId\":\"1\",\"comment\":\"good\"}"
 }
 ```
-
-Note that to run locally, you need to export any environment variables used in code to your current environment. They can be found in the AWS Lambda configurations.
 
 #### Running the local dev database
 ##### Installation

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ Deployment to AWS is done locally on the command line and is _not_ yet connected
 
 The code can be deployed to either the dev account (`Innov-Platform-Dev`) or to the prod account (`Innov-Platform-Prod`). 
 
-> :warning: Please be careful to deploy to the prod account only with extreme caution and after thoroughly testing changes in dev. **Make sure to test that sending requests to our redirect dummy app works before deploying to prod** (see [Test API Requests](#test-api-requests) for instructions). This ensures that the API works with requests sent to a redirect URL.
+> :warning: Please be careful to deploy to the prod account only with extreme caution and after thoroughly testing changes in dev. **Make sure to test that API requests work in the browser before deploying to prod** (see [Test API Requests in the browser](#test-api-requests-in-the-browser) for instructions). This ensures that CORS is enabled properly.
 
+To deploy to the  dev/prod AWS account:
 1. Make code changes locally
 2. Test code changes locally
 3. Log into AWS console, and open "Command line and programmatic access" option under the appropriate account
@@ -46,17 +47,17 @@ This template contains a single lambda function triggered by an HTTP request mad
 
 ### In dev
 
-#### Test API Requests
+#### Test API requests (non-browser)
 
 This section includes test requests for testing the Feedback API Lambdas/endpoints. Update the body of the request as needed to test different scenarios.
 
-There are three different methods for testing these requests:
+There are three different methods for testing these requests outside the browser:
 
 1. **Run requests as JSON via the AWS console**: Go to the "Testing" tab in the Lambda console for the appropriate function.
 2. **Send API requests to the dev API Gateway URL**. Go the API Gateway resource in the AWS console to find the URL. The URL can also be found in the ResX Bitwarden under the `Feedback API Testing Info` item.
 
 3. **Send API requests to our dummy app for testing redirects**. 
-    - In production, the frontend feedback widget doesn't send requests directly to the API Gateway URL. Instead, the widget sends requests to a URL on the Innovation site which then redirects to the prod API Gateway URL. **Testing via this method is crucial because the API can behave differently or even break depending on whether you call it directly vs. via a redirect** (e.g. due to CORS issues).
+    - In production, the frontend feedback widget doesn't send requests directly to the API Gateway URL. Instead, the widget sends requests to a URL on the Innovation site which then redirects to the prod API Gateway URL. 
     - The URL and test CURL requests can be found in the ResX Bitwarden under the `Feedback API Testing Info` item.
 
 > :warning: **Please note that all requests will write directly to the Prod Google Sheet for the time being.** After running requests, be sure to remove any changes from the spreadsheet
@@ -90,6 +91,19 @@ There are three different methods for testing these requests:
   "body": "{\"feedbackId\":\"1\",\"comment\":\"good\"}"
 }
 ```
+
+#### Test API requests in the browser
+
+**It is crucial to test API requests in the browser before deploying to prod, because only web browsers enforce CORS. Non-browser clients (e.g. cURL, Postman, etc.) bypass CORS restrictions entirely.**
+
+Test the dev API deployment in the browser by running the front-end feedback widget component locally and redirecting its API requests to the dev API Gateway URL:
+
+1. Clone the [feedback-widget](https://github.com/newjersey/feedback-widget) repo.
+2. Update the [`API_URL` in feedback-widget.js](https://github.com/newjersey/feedback-widget/blob/52d7f6d10518ed721b232112421d46a1deb18593/feedback-widget.js#L64) to the dev API Gateway URL.
+    - To find the URL in the AWS Console, first make sure you're logged into the Innov-Platform-Dev account! Then search "API Gateway" -> click "Feedback API" in the list of APIs -> click "Stages" in the sidebar -> "Invoke URL" under "Stage details"
+3. Open the `feedback-widget.html` in the browser — you should see a page containing just the frontend feedback widget component. Test that submiting a rating/comment/email works (use the network tab to ensure requests are being sent to the dev API  URL and are returning a success response).
+
+> :warning: **Please note that all requests will write directly to the Prod Google Sheet for the time being.** After running requests, be sure to remove any changes from the spreadsheet
 
 #### Running the local dev database
 ##### Installation

--- a/infra/lib/feedback-api-stack.ts
+++ b/infra/lib/feedback-api-stack.ts
@@ -87,13 +87,16 @@ export class FeedbackApiStack extends cdk.Stack {
 
     const feedbackApi = new apigw.RestApi(this, 'feedback-api', {
       restApiName: 'Feedback API',
-      description: 'API for Feedback Widget functions'
+      description: 'API for Feedback Widget functions',
+      defaultCorsPreflightOptions: {
+        allowOrigins: apigw.Cors.ALL_ORIGINS,
+        allowMethods: ['OPTIONS', 'POST']
+      }
     });
 
     functions.forEach(({ name, handler }) => {
       const resource = feedbackApi.root.addResource(name);
       resource.addMethod('POST', new apigw.LambdaIntegration(handler, {}));
-      resource.addMethod('OPTIONS', new apigw.LambdaIntegration(handler, {}));
 
       new cdk.CfnOutput(this, `${name}FunctionArnOutput`, {
         key: `${name}FunctionArn`,

--- a/infra/lib/feedback-api-stack.ts
+++ b/infra/lib/feedback-api-stack.ts
@@ -90,8 +90,8 @@ export class FeedbackApiStack extends cdk.Stack {
       description: 'API for Feedback Widget functions',
       defaultCorsPreflightOptions: {
         allowOrigins: apigw.Cors.ALL_ORIGINS,
-        allowHeaders: apigw.Cors.DEFAULT_HEADERS,
-        allowMethods: ['POST']
+        allowMethods: ['POST'],
+        allowHeaders: apigw.Cors.DEFAULT_HEADERS
       }
     });
 

--- a/infra/lib/feedback-api-stack.ts
+++ b/infra/lib/feedback-api-stack.ts
@@ -90,7 +90,8 @@ export class FeedbackApiStack extends cdk.Stack {
       description: 'API for Feedback Widget functions',
       defaultCorsPreflightOptions: {
         allowOrigins: apigw.Cors.ALL_ORIGINS,
-        allowMethods: ['OPTIONS', 'POST']
+        allowHeaders: apigw.Cors.DEFAULT_HEADERS,
+        allowMethods: ['POST']
       }
     });
 

--- a/infra/test/feedback-api-stack.test.ts
+++ b/infra/test/feedback-api-stack.test.ts
@@ -3,6 +3,7 @@ import { Capture, Template } from 'aws-cdk-lib/assertions';
 import { FeedbackApiStack } from '../lib/feedback-api-stack';
 import path from 'path';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
+import * as apigw from 'aws-cdk-lib/aws-apigateway';
 
 describe('Feedback API Stack', () => {
   const createStackAndTemplate = (): {
@@ -50,9 +51,21 @@ describe('Feedback API Stack', () => {
       expect(integrationResponses).toContainEqual({
         StatusCode: '204',
         ResponseParameters: expect.objectContaining({
-          'method.response.header.Access-Control-Allow-Origin': "'*'",
-          'method.response.header.Access-Control-Allow-Methods':
-            "'OPTIONS,POST'"
+          'method.response.header.Access-Control-Allow-Origin': "'*'"
+        })
+      });
+
+      expect(integrationResponses).toContainEqual({
+        StatusCode: '204',
+        ResponseParameters: expect.objectContaining({
+          'method.response.header.Access-Control-Allow-Methods': "'POST'"
+        })
+      });
+
+      expect(integrationResponses).toContainEqual({
+        StatusCode: '204',
+        ResponseParameters: expect.objectContaining({
+          'method.response.header.Access-Control-Allow-Headers': `'${apigw.Cors.DEFAULT_HEADERS.join()}'`
         })
       });
     }

--- a/src/functions/comment.test.ts
+++ b/src/functions/comment.test.ts
@@ -13,6 +13,19 @@ describe('comment Lambda', () => {
 
   beforeEach(() => jest.resetAllMocks());
 
+  it('returns a 200 success response when request contains a feedbackId and comment', async () => {
+    const testEvent = {
+      body: JSON.stringify({
+        feedbackId: 1,
+        comment: 'test comment'
+      })
+    } as APIGatewayProxyEvent;
+
+    const response = await handler(testEvent);
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['Access-Control-Allow-Origin']).toBe('*');
+  });
+
   describe('expected 500 errors', () => {
     beforeAll(() => jest.spyOn(console, 'error').mockImplementation(jest.fn()));
     afterAll(() => jest.spyOn(console, 'error').mockRestore());

--- a/src/functions/comment.test.ts
+++ b/src/functions/comment.test.ts
@@ -13,7 +13,7 @@ describe('comment Lambda', () => {
 
   beforeEach(() => jest.resetAllMocks());
 
-  it('returns a 200 success response when request contains a feedbackId and comment', async () => {
+  it("returns a response containing the 'Access-Control-Allow-Origin':'*' header to enable CORS", async () => {
     const testEvent = {
       body: JSON.stringify({
         feedbackId: 1,

--- a/src/functions/email.test.ts
+++ b/src/functions/email.test.ts
@@ -1,0 +1,26 @@
+import * as googleSheetsUtils from '../shared/utils/googleSheetsUtils';
+import * as awsUtils from '../shared/utils/awsUtils';
+import { APIGatewayProxyEvent } from 'aws-lambda';
+import { handler } from './email';
+
+const TEST_FEEDBACK_ID = 1;
+const TEST_EMAIL = 'example@test.com';
+
+describe('rating Lambda', () => {
+  jest.spyOn(googleSheetsUtils, 'updateFeedback').mockImplementation(jest.fn());
+  jest.spyOn(googleSheetsUtils, 'getAuthClient').mockImplementation(jest.fn());
+  jest.spyOn(awsUtils, 'getSsmParam').mockImplementation(jest.fn());
+
+  it('returns a 200 success response when request contains a feedbackId and email', async () => {
+    const testEvent = {
+      body: JSON.stringify({
+        feedbackId: TEST_FEEDBACK_ID,
+        email: TEST_EMAIL
+      })
+    } as APIGatewayProxyEvent;
+
+    const response = await handler(testEvent);
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['Access-Control-Allow-Origin']).toBe('*');
+  });
+});

--- a/src/functions/email.test.ts
+++ b/src/functions/email.test.ts
@@ -11,7 +11,7 @@ describe('rating Lambda', () => {
   jest.spyOn(googleSheetsUtils, 'getAuthClient').mockImplementation(jest.fn());
   jest.spyOn(awsUtils, 'getSsmParam').mockImplementation(jest.fn());
 
-  it('returns a 200 success response when request contains a feedbackId and email', async () => {
+  it("returns a response containing the 'Access-Control-Allow-Origin':'*' header to enable CORS", async () => {
     const testEvent = {
       body: JSON.stringify({
         feedbackId: TEST_FEEDBACK_ID,

--- a/src/functions/rating.test.ts
+++ b/src/functions/rating.test.ts
@@ -1,0 +1,26 @@
+import * as googleSheetsUtils from '../shared/utils/googleSheetsUtils';
+import * as awsUtils from '../shared/utils/awsUtils';
+import { APIGatewayProxyEvent } from 'aws-lambda';
+import { handler } from './rating';
+
+const TEST_PAGE_URL = 'example.com';
+const TEST_RATING = false;
+
+describe('rating Lambda', () => {
+  jest.spyOn(googleSheetsUtils, 'createFeedback').mockImplementation(jest.fn());
+  jest.spyOn(googleSheetsUtils, 'getAuthClient').mockImplementation(jest.fn());
+  jest.spyOn(awsUtils, 'getSsmParam').mockImplementation(jest.fn());
+
+  it('returns a 200 success response when request contains a pageURL and rating', async () => {
+    const testEvent = {
+      body: JSON.stringify({
+        pageURL: TEST_PAGE_URL,
+        rating: TEST_RATING
+      })
+    } as APIGatewayProxyEvent;
+
+    const response = await handler(testEvent);
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['Access-Control-Allow-Origin']).toBe('*');
+  });
+});

--- a/src/functions/rating.test.ts
+++ b/src/functions/rating.test.ts
@@ -11,7 +11,7 @@ describe('rating Lambda', () => {
   jest.spyOn(googleSheetsUtils, 'getAuthClient').mockImplementation(jest.fn());
   jest.spyOn(awsUtils, 'getSsmParam').mockImplementation(jest.fn());
 
-  it('returns a 200 success response when request contains a pageURL and rating', async () => {
+  it("returns a response containing the 'Access-Control-Allow-Origin':'*' header to enable CORS", async () => {
     const testEvent = {
       body: JSON.stringify({
         pageURL: TEST_PAGE_URL,


### PR DESCRIPTION
### Description

This ticket adds the `Access-Control-Allow-Origin` and `Access-Control-Allow-Headers` to the Feedback API's preflight requests. This resolves the CORS issue that caused an outage on 2025-08-26 (see [outage doc](https://docs.google.com/document/d/1-8EyzvyVEpYxSif-pfJ0rft4E-yI9-PBpPu-18R44wA/edit?tab=t.0#heading=h.ks8pez39zxhe)).

Additionally, adds units tests for the rating/comment/email Lambda handlers to check that CORS headers are being included in the response. 

### Testing strategy
#### Unit tests
1. `npm install`
2. `npm run test`

##### Steps to test
Test the dev API deployment in the browser by running the front-end feedback widget component locally and redirecting its API requests to the dev API Gateway URL:

1. Clone the [feedback-widget](https://github.com/newjersey/feedback-widget) repo.
2. Update the [`API_URL` in feedback-widget.js](https://github.com/newjersey/feedback-widget/blob/52d7f6d10518ed721b232112421d46a1deb18593/feedback-widget.js#L64) to the dev API Gateway URL.
    - To find the URL in the AWS Console, first make sure you're logged into the Innov-Platform-Dev account! Then search "API Gateway" -> click "Feedback API" in the list of APIs -> click "Stages" in the sidebar -> "Invoke URL" under "Stage details"
3. Open the `feedback-widget.html` in the browser — you should see a page containing just the frontend feedback widget component. Test that submiting a rating/comment/email works (use the network tab to ensure requests are being sent to the dev API URL and are returning a success response).

**Note: Submitting feedback via the widget will write to the production feedback Google Sheet.** Please delete them from the sheet after testing if you have access, or ask a Platforms engineer to do so for you. 

### Additional resources
- ["Enabling CORS for a non-simple request" (AWS docs)](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-cors.html#apigateway-enable-cors-non-simple).
